### PR TITLE
fix yanked ioctl dep, fix substraction underflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@
 
 	crc = "1.4"
 	flate2 = "0.2"
-	ioctl = "0.3"
+	nix = "0.8.1"
 	lazy_static = "0.2"
 	libc = "0.2"
 	minilzo = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![ allow (unused_parens) ]
 
 #[ macro_use ]
-extern crate ioctl;
+extern crate nix;
 
 #[ macro_use ]
 extern crate lazy_static;

--- a/src/linux/operations/deduplicate.rs
+++ b/src/linux/operations/deduplicate.rs
@@ -107,12 +107,12 @@ pub fn deduplicate_range (
 
 	};
 
-	if file_dedupe_range_result != 0 {
+	if let Err(e) = file_dedupe_range_result {
 
 		return Err (
 			format! (
 				"Dedupe ioctl returned {}",
-				file_dedupe_range_result)
+				e)
 		);
 
 	}

--- a/src/linux/operations/defragment.rs
+++ b/src/linux/operations/defragment.rs
@@ -77,19 +77,14 @@ pub fn defragment_range (
 		)
 	};
 
-	if ioctl_result != 0 {
-
-		return Err (
-			format! (
+	match ioctl_result {
+		Ok(_) => Ok(()),
+		Err(e) => {
+			Err(format! (
 				"Defragment IOCTL returned {}",
-				ioctl_result));
-
+				e))
+		}
 	}
-
-	// return ok
-
-	Ok (())
-
 }
 
 // ex: noet ts=4 filetype=rust

--- a/src/linux/operations/fiemap.rs
+++ b/src/linux/operations/fiemap.rs
@@ -56,9 +56,14 @@ pub fn get_file_extent_map (
 
 		if extent_count != 0 {
 
+			let mapped_count = c_file_extent_map.info.mapped_extents as usize;
+			// file without extents, e.g. due to delayed allocation
+			if mapped_count == 0 {
+				break;
+			}
+
 			let last_mapped_extent =
-				c_file_extent_map.extents [
-					c_file_extent_map.info.mapped_extents as usize - 1];
+				c_file_extent_map.extents [mapped_count - 1];
 
 			if last_mapped_extent.flags & FIEMAP_EXTENT_LAST != 0 {
 				break;
@@ -178,7 +183,7 @@ fn get_c_file_extent_map (
 
 	};
 
-	if fiemap_result != 0 {
+	if let Err(e) = fiemap_result {
 
 		return Err (
 			"Error getting file extent map".to_string ()

--- a/src/linux/operations/filesystem_info.rs
+++ b/src/linux/operations/filesystem_info.rs
@@ -28,7 +28,7 @@ pub fn get_filesystem_info (
 
 	};
 
-	if get_fs_info_result != 0 {
+	if let Err(e) = get_fs_info_result {
 
 		return Err (
 			"Error getting btrfs filesystem information".to_string ()
@@ -77,7 +77,7 @@ pub fn get_device_info (
 
 	};
 
-	if get_dev_info_result != 0 {
+	if let Err(e) = get_dev_info_result {
 
 		match io::Error::last_os_error ().raw_os_error () {
 

--- a/src/linux/operations/space_info.rs
+++ b/src/linux/operations/space_info.rs
@@ -131,7 +131,7 @@ fn get_c_space_info (
 				c_space_args as * mut IoctlSpaceArgs)
 		};
 
-	if get_space_args_real_result != 0 {
+	if let Err(e) = get_space_args_real_result {
 
 		return Err (
 			"Error getting btrfs space information".to_string ()


### PR DESCRIPTION
Fixes issues #2 and #3 reported on gitlab repo.

Replaced *ioctl* crate with *nix* crate. The functions created by the nix `ioctl!` macros have a different signature, so I had to change the error handling a bit.

I have only tested the `fiemap` ioctl since that's the one I am using myself. So the other ones could benefit from some additional testing